### PR TITLE
[installation.html.haml] Chocolatey mpv -> mpvio

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -25,7 +25,7 @@ title: Installation
                     :"cloud-download"
       = package_row 'Scoop', 'https://github.com/lukesampson/scoop-extras/blob/master/bucket/mpv.json'
       = package_row 'Scoop (git)', 'https://github.com/lukesampson/scoop-extras/blob/master/bucket/mpv-git.json'
-      = package_row 'Chocolatey', 'https://chocolatey.org/packages/mpv'
+      = package_row 'Chocolatey', 'https://chocolatey.org/packages/mpvio'
       = package_row 'Compilation instructions', 'https://github.com/mpv-player/mpv/blob/master/DOCS/compile-windows.md'
       = package_row 'MSYS2 source package', 'https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-mpv'
 


### PR DESCRIPTION
Chocolatey `mpv` is not updated anymore. [Quote](https://community.chocolatey.org/packages/mpv#description):

> What's the difference between this package and mpvio? None, but this package is stuck following a now defunct version scheme of mpv.

Superseeding package (from same mantainer) mentioned right in the quote.